### PR TITLE
Fix removed line numbering

### DIFF
--- a/parse_diff_generate_html.py
+++ b/parse_diff_generate_html.py
@@ -240,6 +240,7 @@ class GitCommitReviewGenerator:
                 html_lines.append("<td class='diff-line-num'></td>")
                 html_lines.append(f"<td class='diff-line-content'>{html.escape(line[1:])}</td>")
                 html_lines.append("</tr>")
+                old_line_num += 1
             elif line.startswith(' '):
                 # Context line
                 html_lines.append("<tr class='diff-context'>")


### PR DESCRIPTION
## Summary
- increment the old line counter when processing removed lines

## Testing
- `python3 -m py_compile parse_diff_generate_html.py`

------
https://chatgpt.com/codex/tasks/task_e_6845053c38d4832cad774b7379a4c1b4