### PR TITLE
Fix expand row layout

### DIFF
--- a/parse_diff_generate_html.py
+++ b/parse_diff_generate_html.py
@@ -806,7 +806,7 @@ class GitCommitReviewGenerator:
                         if (nextStart <= nextEnd && hasHiddenLines(nextStart, nextEnd)) {
                             let newBtnRow = document.createElement('tr');
                             newBtnRow.className = 'expand-row';
-                            newBtnRow.innerHTML = `<td class='diff-sign'>&nbsp;</td><td class='diff-line-num'></td><td class='diff-line-num'><button class='expand-icon' data-expand='above-10' data-context-start='${nextStart}' data-context-end='${nextEnd}' title='Show 10 lines above'>▲10</button> <button class='expand-icon' data-expand='above' data-context-start='${nextStart}' data-context-end='${nextEnd}' title='Show more above'>▲</button></td><td class='diff-line-content'></td>`;
+                            newBtnRow.innerHTML = `<td class='diff-line-num'></td><td class='diff-line-num'></td><td class='diff-line-content'><button class='expand-icon' data-expand='above-10' data-context-start='${nextStart}' data-context-end='${nextEnd}' title='Show 10 lines above'>▲10</button> <button class='expand-icon' data-expand='above' data-context-start='${nextStart}' data-context-end='${nextEnd}' title='Show more above'>▲</button></td>`;
                             table.tBodies[0].insertBefore(newBtnRow, insertedRows[0]);
                             newBtnRow.querySelectorAll('.expand-icon').forEach(newBtn => newBtn.addEventListener('click', arguments.callee));
                         }
@@ -818,7 +818,7 @@ class GitCommitReviewGenerator:
                         if (nextStart <= nextEnd && hasHiddenLines(nextStart, nextEnd)) {
                             let newBtnRow = document.createElement('tr');
                             newBtnRow.className = 'expand-row';
-                            newBtnRow.innerHTML = `<td class='diff-sign'>&nbsp;</td><td class='diff-line-num'></td><td class='diff-line-num'><button class='expand-icon' data-expand='below-10' data-context-start='${nextStart}' data-context-end='${nextEnd}' title='Show 10 lines below'>▼10</button> <button class='expand-icon' data-expand='below' data-context-start='${nextStart}' data-context-end='${nextEnd}' title='Show more below'>▼</button></td><td class='diff-line-content'></td>`;
+                            newBtnRow.innerHTML = `<td class='diff-line-num'></td><td class='diff-line-num'></td><td class='diff-line-content'><button class='expand-icon' data-expand='below-10' data-context-start='${nextStart}' data-context-end='${nextEnd}' title='Show 10 lines below'>▼10</button> <button class='expand-icon' data-expand='below' data-context-start='${nextStart}' data-context-end='${nextEnd}' title='Show more below'>▼</button></td>`;
                             let insertAfter = insertedRows[insertedRows.length - 1];
                             if (insertAfter && insertAfter.nextSibling) {
                                 table.tBodies[0].insertBefore(newBtnRow, insertAfter.nextSibling);
@@ -1027,7 +1027,7 @@ class GitCommitReviewGenerator:
                     # All gaps between hunks should be "Show more above" since they appear above the next hunk
                     # Show both 10-line and full expansion buttons
                     html_lines.append(
-                        f"<tr class='expand-row'><td class='diff-sign'>&nbsp;</td><td class='diff-line-num'></td><td class='diff-line-num'><button class='expand-icon' data-expand='above-10' data-context-start='{context_start}' data-context-end='{context_end}' title='Show 10 lines above'>▲10</button> <button class='expand-icon' data-expand='above' data-context-start='{context_start}' data-context-end='{context_end}' title='Show more above'>▲</button></td><td class='diff-line-content'></td></tr>"
+                        f"<tr class='expand-row'><td class='diff-line-num'></td><td class='diff-line-num'></td><td class='diff-line-content'><button class='expand-icon' data-expand='above-10' data-context-start='{context_start}' data-context-end='{context_end}' title='Show 10 lines above'>▲10</button> <button class='expand-icon' data-expand='above' data-context-start='{context_start}' data-context-end='{context_end}' title='Show more above'>▲</button></td></tr>"
                     )
             # Render hunk header
             hunk_header_line = lines[hunk['diff_idx']]
@@ -1083,7 +1083,7 @@ class GitCommitReviewGenerator:
             context_end = len(full_lines)
             if context_start <= context_end:
                 html_lines.append(
-                    f"<tr class='expand-row'><td class='diff-sign'>&nbsp;</td><td class='diff-line-num'></td><td class='diff-line-num'><button class='expand-icon' data-expand='below-10' data-context-start='{context_start}' data-context-end='{context_end}' title='Show 10 lines below'>▼10</button> <button class='expand-icon' data-expand='below' data-context-start='{context_start}' data-context-end='{context_end}' title='Show more below'>▼</button></td><td class='diff-line-content'></td></tr>"
+                    f"<tr class='expand-row'><td class='diff-line-num'></td><td class='diff-line-num'></td><td class='diff-line-content'><button class='expand-icon' data-expand='below-10' data-context-start='{context_start}' data-context-end='{context_end}' title='Show 10 lines below'>▼10</button> <button class='expand-icon' data-expand='below' data-context-start='{context_start}' data-context-end='{context_end}' title='Show more below'>▼</button></td></tr>"
                 )
         html_lines.append("</table>")
         html_lines.append("</div>")


### PR DESCRIPTION
## Summary
- avoid using diff-line-num cell for expand icons
- remove diff-sign cell in expand rows

## Testing
- `python3 -m py_compile parse_diff_generate_html.py`

------
https://chatgpt.com/codex/tasks/task_e_6845154fe938832c8187ed0546e805f9