### PR TITLE
Fix context expansion position

### DIFF
--- a/parse_diff_generate_html.py
+++ b/parse_diff_generate_html.py
@@ -703,7 +703,7 @@ class GitCommitReviewGenerator:
                     let insertionPoint = null;
                     let rows = Array.from(table.tBodies[0].rows);
                     gitDiffLog(`Total rows in table: ${rows.length}`);
-                    
+
                     for (let i = 0; i < rows.length; i++) {
                         let row = rows[i];
                         let lineNumCells = row.querySelectorAll('.diff-line-num');
@@ -724,8 +724,15 @@ class GitCommitReviewGenerator:
                             gitDiffLog(`Row ${i}: no line number cells (${row.className})`);
                         }
                     }
-                    
-                    // If no insertion point found, insert before the button row
+
+                    // For expanding above, insert before the button row so context appears before the hunk header
+                    // For expanding below, insert after the button row
+                    if (expandType.startsWith('above')) {
+                        insertionPoint = tr;
+                    } else if (expandType.startsWith('below')) {
+                        insertionPoint = tr.nextSibling;
+                    }
+                    // Fallback if insertion point is still null
                     if (!insertionPoint) {
                         insertionPoint = tr;
                         gitDiffLog(`No insertion point found, using button row as insertion point`);


### PR DESCRIPTION
## Summary
- ensure context lines for 'expand above' appear before hunk header

## Testing
- `python3 parse_diff_generate_html.py --help`

------
https://chatgpt.com/codex/tasks/task_e_684518a86120832cb3ddff4c38d0af71